### PR TITLE
This fixes build failure with empty bucket error

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -181,6 +181,7 @@ func (m *Messenger) callMeBack(conn *golem.Connection, msg *golem.Message) *gole
 
 // persist a message
 func (m *Messenger) saveMsg(bucket string, profileID string, msg *MSG) error {
+
 	if msg.ID == "" {
 		msg.ID = getUUID()
 	}

--- a/remix_test.go
+++ b/remix_test.go
@@ -687,6 +687,7 @@ func testServer(t *testing.T) (*httptest.Server, *http.Client, *Remix) {
 		TemplatesExtensions: []string{".tmpl", ".html", ".tpl"},
 		SessMaxAge:          30,
 		SessionPath:         "/",
+		MessagesBucket:"messages",
 	}
 	rx := NewRemix(cfg)
 	jar, err := cookiejar.New(nil)

--- a/utils.go
+++ b/utils.go
@@ -20,7 +20,12 @@ func marshalAndCreate(db nutz.Storage, obj interface{}, buck, key string, nest .
 	if err != nil {
 		return err
 	}
-	c := db.Create(buck, key, data, nest...)
+	if len(nest) > 0 {
+		c := db.Create(buck, key, data, nest...)
+		return c.Error
+
+	}
+	c := db.Create(buck, key, data)
 	return c.Error
 }
 


### PR DESCRIPTION
This fixes test fails, the Remix.cfg was lacking MessagesBucket field resulting into sc creating empty bucket causing an error in the bolt database.
